### PR TITLE
refactor: don't use react's default export

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext } from "react";
+import { createContext, useContext, useState } from "react";
 import type { StoreApi, UseBoundStore } from "zustand";
 
 export const createZustandContext = <
@@ -13,14 +13,14 @@ export const createZustandContext = <
     children?: React.ReactNode;
     initialValue: TInitial;
   }) => {
-    const [store] = React.useState(() => getStore(props.initialValue));
+    const [store] = useState(() => getStore(props.initialValue));
     return <Context.Provider value={store}>{props.children}</Context.Provider>;
   };
 
   return [
     Provider,
     ((selector: Parameters<TStore>[0]) => {
-      const store = React.useContext(Context);
+      const store = useContext(Context);
       if (store === null) {
         console.error("Missing provider for context:", Context);
         throw new Error("Missing provider for context");


### PR DESCRIPTION
It would seem that, in the medium to long term, React wants to get rid of the default export. So I've removed the use of React's default export in this package! 😄

Sources:
https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
https://twitter.com/kentcdodds/status/1321885232878923776